### PR TITLE
Templated squid.conf should include conf.d/*

### DIFF
--- a/templates/squid.conf.j2
+++ b/templates/squid.conf.j2
@@ -2,6 +2,8 @@
 
 http_port {{ squid_port }}
 
+include /etc/squid/conf.d/*.conf
+
 cache_effective_user {{ squid_user }}
 cache_effective_group {{ squid_group }}
 


### PR DESCRIPTION
---
name: Pull request
about: Templated squid.conf should include conf.d/*

---

**Describe the change**
Templated squid.conf should include conf.d/* cause on debian/ubuntu there is an `debian.conf` which should also be loaded. also this change makes it easier to apply other custom configuations which are not covered by the template.

**Testing**
N/A
